### PR TITLE
Use Tailscale HTTP transport for target forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,8 +517,9 @@ log-level: info
 validate-ip: true
 
 # Tailscale configuration (optional)
-ts-authkey: ""
-ts-hostname: hubproxy
+# enable-tailscale: true
+# ts-authkey: ""
+# ts-hostname: hubproxy
 
 # Database configuration
 db: sqlite:hubproxy.db
@@ -541,6 +542,7 @@ Most configuration options can also be set via command-line flags:
 - `--target-url`: Target URL to forward webhooks to
 - `--log-level`: Log level (debug, info, warn, error)
 - `--validate-ip`: Validate that requests come from GitHub IPs
+- `--enable-tailscale`: Enable Tailscale integration
 - `--ts-authkey`: Tailscale auth key for tsnet
 - `--ts-hostname`: Tailscale hostname
 - `--db`: Database URI (e.g., sqlite:file.db, mysql://user:pass@host/db, postgresql://user:pass@host/db)
@@ -584,7 +586,7 @@ To use this feature:
 1. Generate an auth key from your [Tailscale Admin Console](https://login.tailscale.com/admin/settings/keys)
 2. Run hubproxy with the following flags:
    ```bash
-   hubproxy --ts-authkey=ts-abc123... --ts-hostname=hubproxy
+   hubproxy --enable-tailscale --ts-authkey=ts-abc123... --ts-hostname=hubproxy
    ```
 
 Your proxy will be accessible at `hubproxy.<tailnet>.ts.net`. You can customize the hostname using the `--ts-hostname` flag.

--- a/cmd/hubproxy/main.go
+++ b/cmd/hubproxy/main.go
@@ -81,6 +81,7 @@ and your target services.`,
 	flags.String("target-url", "", "Target URL to forward webhooks to")
 	flags.String("log-level", "info", "Log level (debug, info, warn, error)")
 	flags.Bool("validate-ip", true, "Validate that requests come from GitHub IPs")
+	flags.Bool("enable-tailscale", false, "Enable Tailscale integration")
 	flags.String("ts-authkey", "", "Tailscale auth key for tsnet")
 	flags.String("ts-hostname", "hubproxy", "Tailscale hostname (will be <hostname>.<tailnet>.ts.net)")
 	flags.String("db", "", "Database URI (e.g., sqlite:hubproxy.db, mysql://user:pass@host/db, postgres://user:pass@host/db)")
@@ -182,15 +183,11 @@ func run() error {
 	webhookHTTPClient := &http.Client{}
 
 	// Setup optional Tailscale server
-	// TODO: Add more explicit --use-tailscale flag
 	var tsnetServer *tsnet.Server
-	if authKey := viper.GetString("ts-authkey"); authKey != "" {
-		// Run as Tailscale service
-		hostname := viper.GetString("ts-hostname")
-
+	if viper.GetBool("enable-tailscale") {
 		tsnetServer = &tsnet.Server{
-			Hostname: hostname,
-			AuthKey:  authKey,
+			Hostname: viper.GetString("ts-hostname"),
+			AuthKey:  viper.GetString("ts-authkey"),
 			Logf: func(format string, args ...any) {
 				logger.Debug("tsnet: " + fmt.Sprintf(format, args...))
 			},


### PR DESCRIPTION
- [x] Use Tailscale HTTP transport for webhook httpClient
- [x] Also makes the flag to enable Tailscale more explicit rather than just checking if the authkey is set

Closes #19 