### PR TITLE
db metrics

### DIFF
--- a/cmd/hubproxy/main.go
+++ b/cmd/hubproxy/main.go
@@ -90,6 +90,7 @@ and your target services.`,
 	flags.String("ts-authkey", "", "Tailscale auth key for tsnet")
 	flags.String("ts-hostname", "hubproxy", "Tailscale hostname (will be <hostname>.<tailnet>.ts.net)")
 	flags.String("db", "", "Database URI (e.g., sqlite:hubproxy.db, mysql://user:pass@host/db, postgres://user:pass@host/db)")
+	flags.Duration("metrics-interval", 0*time.Minute, "Interval at which to gather database metrics")
 	flags.Bool("test-mode", false, "Skip server startup for testing")
 
 	return cmd
@@ -225,14 +226,18 @@ func run() error {
 		}
 	}
 
+	metricsCollector := storage.NewDBMetricsCollector(store, logger)
+	metricsCollector.StartMetricsCollection(ctx, viper.GetDuration("metrics-interval"))
+
 	// Create webhook handler
 	webhookHandler := webhook.NewHandler(webhook.Options{
-		Secret:     viper.GetString("webhook-secret"),
-		TargetURL:  targetURL,
-		HTTPClient: webhookHTTPClient,
-		Logger:     logger,
-		Store:      store,
-		ValidateIP: viper.GetBool("validate-ip"),
+		Secret:           viper.GetString("webhook-secret"),
+		TargetURL:        targetURL,
+		HTTPClient:       webhookHTTPClient,
+		Logger:           logger,
+		Store:            store,
+		ValidateIP:       viper.GetBool("validate-ip"),
+		MetricsCollector: metricsCollector,
 	})
 
 	// Create webhook server

--- a/internal/integration/tailscale_test.go
+++ b/internal/integration/tailscale_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"tailscale.com/tsnet"
 
+	"hubproxy/internal/storage"
 	"hubproxy/internal/webhook"
 )
 
@@ -53,11 +54,12 @@ func TestTailscaleIntegration(t *testing.T) {
 
 	// Create webhook handler
 	handler := webhook.NewHandler(webhook.Options{
-		Secret:     secret,
-		TargetURL:  targetServer.URL,
-		Store:      store,
-		Logger:     logger,
-		ValidateIP: false,
+		Secret:           secret,
+		TargetURL:        targetServer.URL,
+		Store:            store,
+		Logger:           logger,
+		ValidateIP:       false,
+		MetricsCollector: storage.NewDBMetricsCollector(store, logger),
 	})
 
 	// Create HTTP mux

--- a/internal/storage/metrics.go
+++ b/internal/storage/metrics.go
@@ -1,0 +1,98 @@
+package storage
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	eventCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hubproxy_db_events_count",
+		Help: "Number of events stored in the database",
+	}, []string{"type"})
+)
+
+type DBMetricsCollector struct {
+	storage Storage
+	logger  *slog.Logger
+	queue   chan struct{}
+}
+
+func NewDBMetricsCollector(storage Storage, logger *slog.Logger) *DBMetricsCollector {
+	return &DBMetricsCollector{
+		storage: storage,
+		logger:  logger,
+		queue:   make(chan struct{}, 1),
+	}
+}
+
+func (c *DBMetricsCollector) GatherMetrics(ctx context.Context) error {
+	c.logger.Debug("gathering metrics")
+
+	stats, err := c.storage.GetStats(ctx, time.Time{})
+	if err != nil {
+		return err
+	}
+
+	for eventType, count := range stats {
+		eventCount.WithLabelValues(eventType).Set(float64(count))
+	}
+
+	return nil
+}
+
+func (c *DBMetricsCollector) EnqueueGatherMetrics(ctx context.Context) {
+	select {
+	case c.queue <- struct{}{}:
+		c.logger.Debug("enqueued metrics job")
+	default:
+		c.logger.Debug("metrics job already pending")
+	}
+}
+
+func (c *DBMetricsCollector) StartMetricsCollection(ctx context.Context, interval time.Duration) {
+	if c.storage == nil {
+		c.logger.Debug("storage is nil, not starting metrics collection")
+		return
+	}
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				c.logger.Debug("stopped metrics collector")
+				return
+			case <-c.queue:
+				if err := c.GatherMetrics(ctx); err != nil {
+					c.logger.Error("failed to gather metrics", "error", err)
+				}
+			}
+		}
+	}()
+
+	// interval is optional
+	if interval > 0 {
+		go func() {
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+
+			c.logger.Debug("starting periodic metrics collector", "interval", interval)
+
+			for {
+				select {
+				case <-ctx.Done():
+					c.logger.Debug("stopped periodic metrics collector")
+					return
+				case <-ticker.C:
+					c.EnqueueGatherMetrics(ctx)
+				}
+			}
+		}()
+	}
+
+	c.EnqueueGatherMetrics(ctx)
+}


### PR DESCRIPTION
Only adds a simple `hubproxy_db_events_count{type}` to get started. We can add more later. I didn't want to mess with any db storage files or do any advanced query stuff until #12 is sorted out.

The general idea, in a single node case, is we just enqueue a go routine to refresh these counters after any webhook. Easy. But if you're doing a multi node HA, both nodes could be writing so you're going to need some background task to periodically pull the latest from the db. That's were `--metrics-interval=1m` comes in. It's off by default. But let's document this in the #24 HA section.

Closes #20