### PR TITLE
go 1.24.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23.2'
+        go-version: '1.24.1'
         cache: true
     - name: Install dependencies
       run: make deps
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23.2'
+        go-version: '1.24.1'
         cache: true
     - name: Install dependencies
       run: make deps

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module hubproxy
 
-go 1.23.1
-
-toolchain go1.23.2
+go 1.24.1
 
 require (
 	github.com/Masterminds/squirrel v1.5.4


### PR DESCRIPTION
It seems that golangci-lint now requires the latest go 1.24.1.

```
  golangci-lint run --timeout=5m
  staticcheck ./...
  go vet ./...
  shell: /usr/bin/bash -e {0}
Error: can't load config: the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24.1)
Failed executing command with error: can't load config: the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24.1)
```