### PR TITLE
Replace status with forwarded at column

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -50,7 +50,6 @@ func (h *Handler) ListEvents(w http.ResponseWriter, r *http.Request) {
 	// Parse other filters
 	opts.Repository = query.Get("repository")
 	opts.Sender = query.Get("sender")
-	opts.Status = query.Get("status")
 
 	// Parse since/until
 	if since := query.Get("since"); since != "" {
@@ -175,7 +174,6 @@ func (h *Handler) ReplayEvent(w http.ResponseWriter, r *http.Request) {
 		Payload:      event.Payload,
 		Headers:      event.Headers,
 		CreatedAt:    time.Now(),
-		Status:       "replayed",
 		Repository:   event.Repository,
 		Sender:       event.Sender,
 		ReplayedFrom: event.ID,
@@ -289,7 +287,6 @@ func (h *Handler) ReplayRange(w http.ResponseWriter, r *http.Request) {
 			Payload:      event.Payload,
 			Headers:      event.Headers,
 			CreatedAt:    time.Now(),
-			Status:       "replayed",
 			Repository:   event.Repository,
 			Sender:       event.Sender,
 			ReplayedFrom: event.ID,

--- a/internal/cmd/dev/query/main.go
+++ b/internal/cmd/dev/query/main.go
@@ -50,9 +50,8 @@ func main() {
 
 	// Query events
 	opts := storage.QueryOptions{
-		Limit:  *limit,
-		Since:  time.Now().Add(-*since),
-		Status: "completed",
+		Limit: *limit,
+		Since: time.Now().Add(-*since),
 	}
 	if *eventType != "" {
 		opts.Types = []string{*eventType}
@@ -68,12 +67,11 @@ func main() {
 
 	fmt.Printf("Found %d events (showing %d):\n", total, len(events))
 	for _, event := range events {
-		fmt.Printf("  %s: %s/%s (%s) [%s]\n",
+		fmt.Printf("  %s: %s/%s (%s)\n",
 			event.Type,
 			event.Repository,
 			event.ID,
 			event.CreatedAt.Format(time.RFC3339),
-			event.Status,
 		)
 	}
 }

--- a/internal/graphql/README.md
+++ b/internal/graphql/README.md
@@ -16,7 +16,6 @@ query {
     type: String
     repository: String
     sender: String
-    status: String
     since: DateTime
     until: DateTime
     limit: Int
@@ -27,7 +26,6 @@ query {
       type
       payload
       createdAt
-      status
       error
       repository
       sender
@@ -48,7 +46,6 @@ query {
     type
     payload
     createdAt
-    status
     error
     repository
     sender
@@ -82,7 +79,6 @@ mutation {
       type
       payload
       createdAt
-      status
       repository
       sender
       replayedFrom
@@ -110,7 +106,6 @@ mutation {
       type
       payload
       createdAt
-      status
       repository
       sender
       replayedFrom

--- a/internal/graphql/graphql_test.go
+++ b/internal/graphql/graphql_test.go
@@ -209,7 +209,6 @@ func TestGraphQLMutations(t *testing.T) {
 					events {
 						id
 						type
-						status
 						replayedFrom
 					}
 				}
@@ -243,7 +242,6 @@ func TestGraphQLMutations(t *testing.T) {
 		assert.True(t, strings.HasPrefix(event["id"].(string), "test-event-1-replay-"),
 			"Replayed event ID should start with 'test-event-1-replay-'")
 		assert.Equal(t, "push", event["type"])
-		assert.Equal(t, "replayed", event["status"])
 		assert.Equal(t, "test-event-1", event["replayedFrom"])
 	})
 }
@@ -310,7 +308,6 @@ func setupTestData(t *testing.T, store storage.Storage) {
 		Payload:    []byte(`{"ref": "refs/heads/main"}`),
 		Headers:    []byte(`{"X-GitHub-Event": ["push"], "X-GitHub-Delivery": ["test-event-1"]}`),
 		CreatedAt:  now.Add(-1 * time.Hour),
-		Status:     "completed",
 		Repository: "test/repo",
 		Sender:     "test-user",
 	}
@@ -321,7 +318,6 @@ func setupTestData(t *testing.T, store storage.Storage) {
 		Payload:    []byte(`{"action": "opened"}`),
 		Headers:    []byte(`{"X-GitHub-Event": ["pull_request"], "X-GitHub-Delivery": ["test-event-2"]}`),
 		CreatedAt:  now,
-		Status:     "pending",
 		Repository: "test/repo",
 		Sender:     "test-user",
 	}

--- a/internal/graphql/resolvers.go
+++ b/internal/graphql/resolvers.go
@@ -32,10 +32,6 @@ func (s *Schema) resolveEvents(p graphql.ResolveParams) (interface{}, error) {
 		opts.Sender = sender
 	}
 
-	if status, ok := p.Args["status"].(string); ok && status != "" {
-		opts.Status = status
-	}
-
 	// Parse since/until
 	if since, ok := p.Args["since"].(time.Time); ok {
 		opts.Since = since
@@ -137,7 +133,6 @@ func (s *Schema) resolveReplayEvent(p graphql.ResolveParams) (interface{}, error
 		Payload:      event.Payload,
 		Headers:      event.Headers,
 		CreatedAt:    time.Now(),
-		Status:       "replayed",
 		Repository:   event.Repository,
 		Sender:       event.Sender,
 		ReplayedFrom: event.ID,
@@ -215,7 +210,6 @@ func (s *Schema) resolveReplayRange(p graphql.ResolveParams) (interface{}, error
 			Payload:      event.Payload,
 			Headers:      event.Headers,
 			CreatedAt:    time.Now(),
-			Status:       "replayed",
 			Repository:   event.Repository,
 			Sender:       event.Sender,
 			ReplayedFrom: event.ID,

--- a/internal/storage/sql/base.go
+++ b/internal/storage/sql/base.go
@@ -44,14 +44,13 @@ func (s *BaseStorage) StoreEvent(ctx context.Context, event *storage.Event) erro
 	// Use the existing builder's placeholder format
 	query := s.builder.
 		Insert(s.tableName).
-		Columns("id", "type", "payload", "headers", "created_at", "status", "error", "repository", "sender").
+		Columns("id", "type", "payload", "headers", "created_at", "error", "repository", "sender").
 		Values(
 			event.ID,
 			event.Type,
 			event.Payload,
 			event.Headers,
 			event.CreatedAt,
-			event.Status,
 			event.Error,
 			event.Repository,
 			event.Sender,
@@ -78,7 +77,7 @@ func (s *BaseStorage) StoreEvent(ctx context.Context, event *storage.Event) erro
 func (s *BaseStorage) ListEvents(ctx context.Context, opts storage.QueryOptions) ([]*storage.Event, int, error) {
 	// Build base query
 	query := s.builder.Select(
-		"id", "type", "payload", "headers", "created_at", "status", "error", "repository", "sender",
+		"id", "type", "payload", "headers", "created_at", "error", "repository", "sender",
 	).From(s.tableName)
 
 	// Add conditions
@@ -122,7 +121,6 @@ func (s *BaseStorage) ListEvents(ctx context.Context, opts storage.QueryOptions)
 			&event.Payload,
 			&event.Headers,
 			&event.CreatedAt,
-			&event.Status,
 			&event.Error,
 			&event.Repository,
 			&event.Sender,
@@ -190,9 +188,7 @@ func (s *BaseStorage) GetStats(ctx context.Context, since time.Time) (map[string
 
 // GetEvent returns a single event by ID
 func (s *BaseStorage) GetEvent(ctx context.Context, id string) (*storage.Event, error) {
-	query := s.builder.
-		Select("id", "type", "payload", "headers", "created_at", "status", "error", "repository", "sender").
-		From(s.tableName).
+	query := s.builder.Select("id", "type", "payload", "headers", "created_at", "error", "repository", "sender").From(s.tableName).
 		Where(sq.Eq{"id": id}).
 		Limit(1)
 
@@ -213,7 +209,6 @@ func (s *BaseStorage) GetEvent(ctx context.Context, id string) (*storage.Event, 
 		&event.Payload,
 		&event.Headers,
 		&event.CreatedAt,
-		&event.Status,
 		&event.Error,
 		&event.Repository,
 		&event.Sender,
@@ -236,9 +231,7 @@ func (s *BaseStorage) addQueryConditions(query sq.SelectBuilder, opts storage.Qu
 	if !opts.Until.IsZero() {
 		query = query.Where(sq.LtOrEq{"created_at": opts.Until})
 	}
-	if opts.Status != "" {
-		query = query.Where(sq.Eq{"status": opts.Status})
-	}
+
 	if opts.Repository != "" {
 		query = query.Where(sq.Eq{"repository": opts.Repository})
 	}

--- a/internal/storage/sql/dialect.go
+++ b/internal/storage/sql/dialect.go
@@ -45,7 +45,6 @@ func (d *BaseDialect) CreateTableSQL(tableName string) string {
 			headers %s,
 			created_at %s NOT NULL,
 			forwarded_at %s,
-			status VARCHAR(20) NOT NULL,
 			error TEXT,
 			repository VARCHAR(255),
 			sender VARCHAR(255),
@@ -55,10 +54,9 @@ func (d *BaseDialect) CreateTableSQL(tableName string) string {
 		CREATE INDEX IF NOT EXISTS idx_created_at ON %s (created_at);
 		CREATE INDEX IF NOT EXISTS idx_forwarded_at ON %s (forwarded_at);
 		CREATE INDEX IF NOT EXISTS idx_type ON %s (type);
-		CREATE INDEX IF NOT EXISTS idx_status ON %s (status);
 		CREATE INDEX IF NOT EXISTS idx_repository ON %s (repository);
 		CREATE INDEX IF NOT EXISTS idx_sender ON %s (sender);
 		CREATE INDEX IF NOT EXISTS idx_replayed_from ON %s (replayed_from);
 	`, tableName, d.JSONType(), d.JSONType(), d.TimeType(), d.TimeType(), d.TimeType(),
-		tableName, tableName, tableName, tableName, tableName, tableName, tableName)
+		tableName, tableName, tableName, tableName, tableName, tableName)
 }

--- a/internal/storage/sql/dialect.go
+++ b/internal/storage/sql/dialect.go
@@ -44,6 +44,7 @@ func (d *BaseDialect) CreateTableSQL(tableName string) string {
 			payload %s NOT NULL,
 			headers %s,
 			created_at %s NOT NULL,
+			forwarded_at %s,
 			status VARCHAR(20) NOT NULL,
 			error TEXT,
 			repository VARCHAR(255),
@@ -52,11 +53,12 @@ func (d *BaseDialect) CreateTableSQL(tableName string) string {
 			original_time %s
 		);
 		CREATE INDEX IF NOT EXISTS idx_created_at ON %s (created_at);
+		CREATE INDEX IF NOT EXISTS idx_forwarded_at ON %s (forwarded_at);
 		CREATE INDEX IF NOT EXISTS idx_type ON %s (type);
 		CREATE INDEX IF NOT EXISTS idx_status ON %s (status);
 		CREATE INDEX IF NOT EXISTS idx_repository ON %s (repository);
 		CREATE INDEX IF NOT EXISTS idx_sender ON %s (sender);
 		CREATE INDEX IF NOT EXISTS idx_replayed_from ON %s (replayed_from);
-	`, tableName, d.JSONType(), d.JSONType(), d.TimeType(), d.TimeType(),
-		tableName, tableName, tableName, tableName, tableName, tableName)
+	`, tableName, d.JSONType(), d.JSONType(), d.TimeType(), d.TimeType(), d.TimeType(),
+		tableName, tableName, tableName, tableName, tableName, tableName, tableName)
 }

--- a/internal/storage/sql/storage.go
+++ b/internal/storage/sql/storage.go
@@ -228,6 +228,26 @@ func (s *Storage) UpdateEventStatus(ctx context.Context, id string, status strin
 	return nil
 }
 
+func (s *Storage) MarkForwarded(ctx context.Context, id string) error {
+	query := s.builder.
+		Update(s.tableName).
+		Set("forwarded_at", time.Now()).
+		Where("id = ?", id)
+
+	result, err := query.RunWith(s.db).ExecContext(ctx)
+	if err != nil {
+		return fmt.Errorf("marking event as forwarded: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("getting rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("event not found")
+	}
+	return nil
+}
+
 func (s *Storage) GetStats(ctx context.Context, since time.Time) (map[string]int64, error) {
 	query := s.builder.
 		Select("type", "COUNT(*) as count").

--- a/internal/storage/sql/storage.go
+++ b/internal/storage/sql/storage.go
@@ -201,33 +201,6 @@ func (s *Storage) CountEvents(ctx context.Context, opts storage.QueryOptions) (i
 	return count, nil
 }
 
-func (s *Storage) UpdateEventStatus(ctx context.Context, id string, status string, err error) error {
-	var errStr string
-	if err != nil {
-		errStr = err.Error()
-	}
-
-	query := s.builder.
-		Update(s.tableName).
-		Set("error", errStr).
-		Where("id = ?", id)
-
-	result, err := query.RunWith(s.db).ExecContext(ctx)
-	if err != nil {
-		return fmt.Errorf("updating event status: %w", err)
-	}
-
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("getting rows affected: %w", err)
-	}
-	if rows == 0 {
-		return fmt.Errorf("event not found")
-	}
-
-	return nil
-}
-
 func (s *Storage) MarkForwarded(ctx context.Context, id string) error {
 	query := s.builder.
 		Update(s.tableName).

--- a/internal/storage/sql/storage.go
+++ b/internal/storage/sql/storage.go
@@ -107,7 +107,7 @@ func (s *Storage) StoreEvent(ctx context.Context, event *storage.Event) error {
 
 func (s *Storage) GetEvent(ctx context.Context, id string) (*storage.Event, error) {
 	query := s.builder.
-		Select("id", "type", "payload", "created_at", "status", "error", "repository", "sender").
+		Select("id", "type", "payload", "created_at", "error", "repository", "sender").
 		From(s.tableName).
 		Where("id = ?", id).
 		Limit(1)
@@ -119,7 +119,6 @@ func (s *Storage) GetEvent(ctx context.Context, id string) (*storage.Event, erro
 		&event.Type,
 		&payload,
 		&event.CreatedAt,
-		&event.Status,
 		&event.Error,
 		&event.Repository,
 		&event.Sender,
@@ -137,7 +136,7 @@ func (s *Storage) GetEvent(ctx context.Context, id string) (*storage.Event, erro
 
 func (s *Storage) ListEvents(ctx context.Context, opts storage.QueryOptions) ([]*storage.Event, int, error) {
 	query := s.builder.
-		Select("id", "type", "payload", "created_at", "status", "error", "repository", "sender").
+		Select("id", "type", "payload", "created_at", "error", "repository", "sender").
 		From(s.tableName)
 
 	query = s.addQueryConditions(query, opts)
@@ -175,7 +174,6 @@ func (s *Storage) ListEvents(ctx context.Context, opts storage.QueryOptions) ([]
 			&event.Type,
 			&payload,
 			&event.CreatedAt,
-			&event.Status,
 			&event.Error,
 			&event.Repository,
 			&event.Sender,
@@ -211,7 +209,6 @@ func (s *Storage) UpdateEventStatus(ctx context.Context, id string, status strin
 
 	query := s.builder.
 		Update(s.tableName).
-		Set("status", status).
 		Set("error", errStr).
 		Where("id = ?", id)
 

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -22,7 +22,6 @@ func TestStorageImplementations(t *testing.T) {
 		Payload:    []byte(`{"ref": "refs/heads/main"}`),
 		Headers:    []byte(`{"X-GitHub-Event": ["push"], "X-GitHub-Delivery": ["test-event-1"]}`),
 		CreatedAt:  time.Now().UTC(),
-		Status:     "pending",
 		Error:      "", // Empty string for no error
 		Repository: "test/repo",
 		Sender:     "test-user",
@@ -38,7 +37,6 @@ func TestStorageImplementations(t *testing.T) {
 		Payload:    []byte(`{"action": "opened"}`),
 		Headers:    []byte(`{"X-GitHub-Event": ["pull_request"], "X-GitHub-Delivery": ["test-event-2"]}`),
 		CreatedAt:  time.Now().UTC(),
-		Status:     "completed",
 		Error:      "",
 		Repository: "test/repo",
 		Sender:     "test-user",
@@ -56,7 +54,6 @@ func TestStorageImplementations(t *testing.T) {
 		Types:      []string{"push"},
 		Repository: "test/repo",
 		Sender:     "test-user",
-		Status:     "pending",
 		Limit:      10,
 		Offset:     0,
 	})
@@ -64,7 +61,7 @@ func TestStorageImplementations(t *testing.T) {
 	assert.Equal(t, 1, total)
 	assert.Len(t, events, 1)
 	assert.Equal(t, event.ID, events[0].ID)
-	assert.Equal(t, "pending", events[0].Status)
+
 	assert.Empty(t, events[0].Error)
 
 	// Test getting event type stats

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -42,6 +42,9 @@ type Storage interface {
 	// StoreEvent stores a webhook event
 	StoreEvent(ctx context.Context, event *Event) error
 
+	// MarkForwarded marks an event as forwarded by setting the forwarded_at timestamp
+	MarkForwarded(ctx context.Context, id string) error
+
 	// ListEvents lists webhook events based on query options
 	ListEvents(ctx context.Context, opts QueryOptions) ([]*Event, int, error)
 

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -13,7 +13,6 @@ type Event struct {
 	Headers      json.RawMessage `json:"headers"`
 	Payload      json.RawMessage `json:"payload"`
 	CreatedAt    time.Time       `json:"created_at"`
-	Status       string          `json:"status"`
 	Error        string          `json:"error,omitempty"`
 	Repository   string          `json:"repository,omitempty"`
 	Sender       string          `json:"sender,omitempty"`
@@ -28,7 +27,6 @@ type QueryOptions struct {
 	Sender     string    // Sender to filter by
 	Since      time.Time // Start time for events
 	Until      time.Time // End time for events
-	Status     string    // Status to filter by
 	Limit      int       // Maximum number of events to return
 	Offset     int       // Offset for pagination
 }

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -274,7 +274,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Headers:    headerJSON,
 		Payload:    json.RawMessage(payload),
 		CreatedAt:  time.Now(),
-		Status:     "received",
 		Repository: "", // Extract from payload if needed
 		Sender:     "", // Extract from payload if needed
 	}

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -310,6 +310,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		} else {
 			webhookForwardedRequests.Inc()
+			err := h.store.MarkForwarded(r.Context(), event.ID)
+			if err != nil {
+				h.logger.Error("error marking event as forwarded", "error", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull request involves the removal of the `Status` field from various parts of the codebase, including tests, handlers, resolvers, and storage implementations. The goal is to simplify the event handling by eliminating the `Status` attribute.

Key changes include:

### Test Updates:
* Removed `Status` field from test cases in `internal/api/api_test.go` [[1]](diffhunk://#diff-4d514085b47744fcdfdda631f3b5e141857e34feb020911194a877879fcf1501L37) [[2]](diffhunk://#diff-4d514085b47744fcdfdda631f3b5e141857e34feb020911194a877879fcf1501L46) [[3]](diffhunk://#diff-4d514085b47744fcdfdda631f3b5e141857e34feb020911194a877879fcf1501L55) [[4]](diffhunk://#diff-4d514085b47744fcdfdda631f3b5e141857e34feb020911194a877879fcf1501L103-L108) [[5]](diffhunk://#diff-4d514085b47744fcdfdda631f3b5e141857e34feb020911194a877879fcf1501L228-R219) [[6]](diffhunk://#diff-4d514085b47744fcdfdda631f3b5e141857e34feb020911194a877879fcf1501L237-R228) [[7]](diffhunk://#diff-4d514085b47744fcdfdda631f3b5e141857e34feb020911194a877879fcf1501L274-L283) [[8]](diffhunk://#diff-4d514085b47744fcdfdda631f3b5e141857e34feb020911194a877879fcf1501L304).
* Updated `internal/graphql/graphql_test.go` to remove `Status` field from test data setup [[1]](diffhunk://#diff-4f814db05738ddf6f20e585163b1707a4d721b8761a4744998dc460e19ac9f66L313) [[2]](diffhunk://#diff-4f814db05738ddf6f20e585163b1707a4d721b8761a4744998dc460e19ac9f66L324).
* Modified `internal/storage/sql/sql_test.go` to remove `Status` field from event handling tests [[1]](diffhunk://#diff-baa7db03d22ebede69a565b557d919c18bd28f22af5f033c535a32476999473dL29) [[2]](diffhunk://#diff-baa7db03d22ebede69a565b557d919c18bd28f22af5f033c535a32476999473dL42-L53) [[3]](diffhunk://#diff-baa7db03d22ebede69a565b557d919c18bd28f22af5f033c535a32476999473dL74) [[4]](diffhunk://#diff-baa7db03d22ebede69a565b557d919c18bd28f22af5f033c535a32476999473dL86-R86) [[5]](diffhunk://#diff-baa7db03d22ebede69a565b557d919c18bd28f22af5f033c535a32476999473dL109-L111).

### Handler and Resolver Updates:
* Removed `Status` field from query parameters and replay event creation in `internal/api/handler.go` [[1]](diffhunk://#diff-4557c0feb4807d067dd963ec1a7d19ad62c17d2ebce2afb769ca83c6c9c58250L53) [[2]](diffhunk://#diff-4557c0feb4807d067dd963ec1a7d19ad62c17d2ebce2afb769ca83c6c9c58250L178) [[3]](diffhunk://#diff-4557c0feb4807d067dd963ec1a7d19ad62c17d2ebce2afb769ca83c6c9c58250L292).
* Removed `Status` field from GraphQL resolvers in `internal/graphql/resolvers.go` [[1]](diffhunk://#diff-6d2fd2ae2498ca07264049b74a45f2114f35cf609a6baa6e638a16ae359c0d64L39-L42) [[2]](diffhunk://#diff-6d2fd2ae2498ca07264049b74a45f2114f35cf609a6baa6e638a16ae359c0d64L156) [[3]](diffhunk://#diff-6d2fd2ae2498ca07264049b74a45f2114f35cf609a6baa6e638a16ae359c0d64L238).

### Storage Implementation Updates:
* Removed `Status` field from event storage and retrieval in `internal/storage/sql/base.go` [[1]](diffhunk://#diff-34c1abdfec64cee13b439994ee5038f8b85eb0683616d4ae6e3ee6dab910a1a9L47-L54) [[2]](diffhunk://#diff-34c1abdfec64cee13b439994ee5038f8b85eb0683616d4ae6e3ee6dab910a1a9L81-R80) [[3]](diffhunk://#diff-34c1abdfec64cee13b439994ee5038f8b85eb0683616d4ae6e3ee6dab910a1a9L125) [[4]](diffhunk://#diff-34c1abdfec64cee13b439994ee5038f8b85eb0683616d4ae6e3ee6dab910a1a9L193-R191) [[5]](diffhunk://#diff-34c1abdfec64cee13b439994ee5038f8b85eb0683616d4ae6e3ee6dab910a1a9L216) [[6]](diffhunk://#diff-34c1abdfec64cee13b439994ee5038f8b85eb0683616d4ae6e3ee6dab910a1a9L239-R234).
* Updated event table schema to remove `Status` column and added `forwarded_at` column in `internal/storage/sql/dialect.go`.

### Command Updates:
* Removed `Status` field from event query options in `internal/cmd/dev/query/main.go` [[1]](diffhunk://#diff-109fd637b0506a00e7a3ba765528140cbf2f547531b56b7e3092404475c71b3cL55) [[2]](diffhunk://#diff-109fd637b0506a00e7a3ba765528140cbf2f547531b56b7e3092404475c71b3cL71-L76).

### Additional Cleanup:
* Removed unnecessary import in `internal/storage/sql/sql_test.go`.