### PR TITLE
Remove dead code

### DIFF
--- a/internal/graphql/schema.go
+++ b/internal/graphql/schema.go
@@ -232,8 +232,3 @@ func NewSchema(store storage.Storage, logger *slog.Logger) (*Schema, error) {
 	s.schema = schema
 	return s, nil
 }
-
-// Schema returns the GraphQL schema
-func (s *Schema) Schema() graphql.Schema {
-	return s.schema
-}

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -8,13 +8,3 @@ type Config struct {
 	Username string
 	Password string
 }
-
-func DefaultConfig() Config {
-	return Config{
-		Host:     "localhost",
-		Port:     5433,
-		Database: "lacrosse",
-		Username: "lacrosse",
-		Password: "lacrosse",
-	}
-}

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -6,8 +6,3 @@ import "errors"
 var (
 	ErrDuplicateKey = errors.New("duplicate key")
 )
-
-// IsDuplicateKeyError returns true if the error is a duplicate key error
-func IsDuplicateKeyError(err error) bool {
-	return errors.Is(err, ErrDuplicateKey)
-}


### PR DESCRIPTION
Found via `$ go run golang.org/x/tools/cmd/deadcode@latest`

This pull request includes several changes focused on removing unused methods and simplifying the codebase. The most important changes include the removal of a method that returns the GraphQL schema, the removal of a default configuration function, and the removal of an error-checking function.

Codebase simplification:

* [`internal/graphql/schema.go`](diffhunk://#diff-570e2142a44b60afdbcdf2dd7a6d2d373438183300fefc11612aef0fda9f3d07L235-L239): Removed the `Schema` method that returned the GraphQL schema.
* [`internal/storage/config.go`](diffhunk://#diff-331da9c0f9c1ebee77735ef5c10da0ec75caf43586d9c280575d78d26f73658aL11-L20): Removed the `DefaultConfig` function that provided default configuration values.
* [`internal/storage/errors.go`](diffhunk://#diff-b3cdcf971ce366d490b03df0be95f7cbf138ce8707e89bf6a8a954a087dad6faL9-L13): Removed the `IsDuplicateKeyError` function that checked for duplicate key errors.