### PR TITLE
Fix loading event headers from get and list

### DIFF
--- a/internal/storage/sql/sql_test.go
+++ b/internal/storage/sql/sql_test.go
@@ -101,3 +101,66 @@ func TestConcurrentEventInsertion(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, stored)
 }
+
+func TestEventHeadersHandling(t *testing.T) {
+	ctx := context.Background()
+	store, err := sql.New("sqlite:file:test_headers.db?mode=memory&cache=shared")
+	require.NoError(t, err)
+	defer store.Close()
+
+	// Create events with different headers
+	events := []*storage.Event{
+		{
+			ID:         "test-headers-1",
+			Type:       "push",
+			Payload:    []byte(`{"ref": "refs/heads/main"}`),
+			Headers:    []byte(`{"X-GitHub-Event": ["push"], "X-GitHub-Delivery": ["test-headers-1"]}`),
+			CreatedAt:  time.Now().UTC(),
+			Repository: "test/repo",
+			Sender:     "test-user",
+		},
+		{
+			ID:         "test-headers-2",
+			Type:       "pull_request",
+			Payload:    []byte(`{"action": "opened"}`),
+			Headers:    []byte(`{"X-GitHub-Event": ["pull_request"], "X-GitHub-Delivery": ["test-headers-2"], "X-Custom-Header": ["test-value"]}`),
+			CreatedAt:  time.Now().UTC(),
+			Repository: "test/repo",
+			Sender:     "test-user",
+		},
+	}
+
+	// Store both events
+	for _, event := range events {
+		err = store.StoreEvent(ctx, event)
+		require.NoError(t, err)
+	}
+
+	// Test GetEvent headers retrieval
+	var stored *storage.Event
+	for _, expected := range events {
+		stored, err = store.GetEvent(ctx, expected.ID)
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		assert.Equal(t, expected.Headers, stored.Headers, "Headers should match for event %s", expected.ID)
+	}
+
+	// Test ListEvents headers retrieval
+	listed, total, err := store.ListEvents(ctx, storage.QueryOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, total, "Should have exactly two events")
+	assert.Len(t, listed, 2, "Should list both events")
+
+	// Create a map of expected events by ID for easier comparison
+	expectedByID := make(map[string]*storage.Event)
+	for _, e := range events {
+		expectedByID[e.ID] = e
+	}
+
+	// Verify headers in listed events
+	for _, actual := range listed {
+		expected := expectedByID[actual.ID]
+		require.NotNil(t, expected, "Should find matching expected event")
+		assert.Equal(t, expected.Headers, actual.Headers, "Headers should match for event %s", actual.ID)
+	}
+}


### PR DESCRIPTION
This pull request introduces support for storing and retrieving event headers in the SQL storage layer. It includes changes to the `StoreEvent`, `GetEvent`, and `ListEvents` methods, as well as the addition of a new test to validate the functionality.

### Enhancements to event storage and retrieval:

* [`internal/storage/sql/storage.go`](diffhunk://#diff-bd51033ee6d0d469cd33a1468f44dc4c4c9713a2d6da1d05c7ff46380b754837L110-R121): Updated the `StoreEvent`, `GetEvent`, and `ListEvents` methods to handle the `Headers` field in events. This involved modifying SQL queries to include the `headers` column and ensuring the `Headers` field is correctly populated when retrieving events. [[1]](diffhunk://#diff-bd51033ee6d0d469cd33a1468f44dc4c4c9713a2d6da1d05c7ff46380b754837L110-R121) [[2]](diffhunk://#diff-bd51033ee6d0d469cd33a1468f44dc4c4c9713a2d6da1d05c7ff46380b754837R135-R142) [[3]](diffhunk://#diff-bd51033ee6d0d469cd33a1468f44dc4c4c9713a2d6da1d05c7ff46380b754837R175-R179) [[4]](diffhunk://#diff-bd51033ee6d0d469cd33a1468f44dc4c4c9713a2d6da1d05c7ff46380b754837R189)

### New test for event headers:

* [`internal/storage/sql/sql_test.go`](diffhunk://#diff-baa7db03d22ebede69a565b557d919c18bd28f22af5f033c535a32476999473dR104-R166): Added `TestEventHeadersHandling` to validate that event headers are stored and retrieved correctly. The test covers storing events with headers, retrieving them individually, and listing them to ensure headers match expectations.