### PR TITLE
Internal Event forwarded at APIs

### DIFF
--- a/internal/storage/sql/base.go
+++ b/internal/storage/sql/base.go
@@ -240,5 +240,8 @@ func (s *BaseStorage) addQueryConditions(query sq.SelectBuilder, opts storage.Qu
 	if opts.Sender != "" {
 		query = query.Where(sq.Eq{"sender": opts.Sender})
 	}
+	if opts.OnlyNonForwarded {
+		query = query.Where("forwarded_at IS NULL")
+	}
 	return query
 }

--- a/internal/storage/sql/base.go
+++ b/internal/storage/sql/base.go
@@ -44,13 +44,14 @@ func (s *BaseStorage) StoreEvent(ctx context.Context, event *storage.Event) erro
 	// Use the existing builder's placeholder format
 	query := s.builder.
 		Insert(s.tableName).
-		Columns("id", "type", "payload", "headers", "created_at", "error", "repository", "sender").
+		Columns("id", "type", "payload", "headers", "created_at", "forwarded_at", "error", "repository", "sender").
 		Values(
 			event.ID,
 			event.Type,
 			event.Payload,
 			event.Headers,
 			event.CreatedAt,
+			event.ForwardedAt,
 			event.Error,
 			event.Repository,
 			event.Sender,
@@ -188,7 +189,7 @@ func (s *BaseStorage) GetStats(ctx context.Context, since time.Time) (map[string
 
 // GetEvent returns a single event by ID
 func (s *BaseStorage) GetEvent(ctx context.Context, id string) (*storage.Event, error) {
-	query := s.builder.Select("id", "type", "payload", "headers", "created_at", "error", "repository", "sender").From(s.tableName).
+	query := s.builder.Select("id", "type", "payload", "headers", "created_at", "forwarded_at", "error", "repository", "sender").From(s.tableName).
 		Where(sq.Eq{"id": id}).
 		Limit(1)
 
@@ -209,6 +210,7 @@ func (s *BaseStorage) GetEvent(ctx context.Context, id string) (*storage.Event, 
 		&event.Payload,
 		&event.Headers,
 		&event.CreatedAt,
+		&event.ForwardedAt,
 		&event.Error,
 		&event.Repository,
 		&event.Sender,

--- a/internal/storage/sql/sql_test.go
+++ b/internal/storage/sql/sql_test.go
@@ -164,3 +164,84 @@ func TestEventHeadersHandling(t *testing.T) {
 		assert.Equal(t, expected.Headers, actual.Headers, "Headers should match for event %s", actual.ID)
 	}
 }
+
+func TestForwardedAtField(t *testing.T) {
+	ctx := context.Background()
+	store, err := sql.New("sqlite:file:test_forwarded.db?mode=memory&cache=shared")
+	require.NoError(t, err)
+	defer store.Close()
+
+	// Create current time for testing
+	now := time.Now().UTC()
+	forwardedTime := now.Add(5 * time.Minute)
+
+	// Create events with different forwarded_at values
+	events := []*storage.Event{
+		{
+			ID:          "test-forwarded-1",
+			Type:        "push",
+			Payload:     []byte(`{"ref": "refs/heads/main"}`),
+			Headers:     []byte(`{"X-GitHub-Event": ["push"], "X-GitHub-Delivery": ["test-forwarded-1"]}`),
+			CreatedAt:   now,
+			ForwardedAt: &forwardedTime, // Event has been forwarded
+			Repository:  "test/repo",
+			Sender:      "test-user",
+		},
+		{
+			ID:          "test-forwarded-2",
+			Type:        "pull_request",
+			Payload:     []byte(`{"action": "opened"}`),
+			Headers:     []byte(`{"X-GitHub-Event": ["pull_request"], "X-GitHub-Delivery": ["test-forwarded-2"]}`),
+			CreatedAt:   now,
+			ForwardedAt: nil, // Event has not been forwarded
+			Repository:  "test/repo",
+			Sender:      "test-user",
+		},
+	}
+
+	// Store both events
+	for _, event := range events {
+		err = store.StoreEvent(ctx, event)
+		require.NoError(t, err)
+	}
+
+	// Test GetEvent forwarded_at retrieval
+	var stored *storage.Event
+	for _, expected := range events {
+		stored, err = store.GetEvent(ctx, expected.ID)
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+
+		if expected.ForwardedAt == nil {
+			assert.Nil(t, stored.ForwardedAt, "ForwardedAt should be nil for event %s", expected.ID)
+		} else {
+			assert.NotNil(t, stored.ForwardedAt, "ForwardedAt should not be nil for event %s", expected.ID)
+			assert.Equal(t, expected.ForwardedAt.Unix(), stored.ForwardedAt.Unix(), "ForwardedAt should match for event %s", expected.ID)
+		}
+	}
+
+	// Test ListEvents forwarded_at retrieval
+	listed, total, err := store.ListEvents(ctx, storage.QueryOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, total, "Should have exactly two events")
+	assert.Len(t, listed, 2, "Should list both events")
+
+	// Create a map of expected events by ID for easier comparison
+	expectedByID := make(map[string]*storage.Event)
+	for _, e := range events {
+		expectedByID[e.ID] = e
+	}
+
+	// Verify forwarded_at in listed events
+	for _, actual := range listed {
+		expected := expectedByID[actual.ID]
+		require.NotNil(t, expected, "Should find matching expected event")
+
+		if expected.ForwardedAt == nil {
+			assert.Nil(t, actual.ForwardedAt, "ForwardedAt should be nil for event %s", expected.ID)
+		} else {
+			assert.NotNil(t, actual.ForwardedAt, "ForwardedAt should not be nil for event %s", expected.ID)
+			assert.Equal(t, expected.ForwardedAt.Unix(), actual.ForwardedAt.Unix(), "ForwardedAt should match for event %s", expected.ID)
+		}
+	}
+}

--- a/internal/storage/sql/sql_test.go
+++ b/internal/storage/sql/sql_test.go
@@ -226,6 +226,14 @@ func TestForwardedAtField(t *testing.T) {
 	assert.Equal(t, 2, total, "Should have exactly two events")
 	assert.Len(t, listed, 2, "Should list both events")
 
+	// Test filtering for non-forwarded events only
+	nonForwardedEvents, nonForwardedTotal, err := store.ListEvents(ctx, storage.QueryOptions{OnlyNonForwarded: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, nonForwardedTotal, "Should have exactly one non-forwarded event")
+	assert.Len(t, nonForwardedEvents, 1, "Should list only non-forwarded events")
+	assert.Equal(t, "test-forwarded-2", nonForwardedEvents[0].ID, "Should be the non-forwarded event")
+	assert.Nil(t, nonForwardedEvents[0].ForwardedAt, "ForwardedAt should be nil for the non-forwarded event")
+
 	// Create a map of expected events by ID for easier comparison
 	expectedByID := make(map[string]*storage.Event)
 	for _, e := range events {

--- a/internal/storage/sql/storage.go
+++ b/internal/storage/sql/storage.go
@@ -107,7 +107,7 @@ func (s *Storage) StoreEvent(ctx context.Context, event *storage.Event) error {
 
 func (s *Storage) GetEvent(ctx context.Context, id string) (*storage.Event, error) {
 	query := s.builder.
-		Select("id", "type", "headers", "payload", "created_at", "error", "repository", "sender").
+		Select("id", "type", "headers", "payload", "created_at", "forwarded_at", "error", "repository", "sender").
 		From(s.tableName).
 		Where("id = ?", id).
 		Limit(1)
@@ -121,6 +121,7 @@ func (s *Storage) GetEvent(ctx context.Context, id string) (*storage.Event, erro
 		&headers,
 		&payload,
 		&event.CreatedAt,
+		&event.ForwardedAt,
 		&event.Error,
 		&event.Repository,
 		&event.Sender,
@@ -139,7 +140,7 @@ func (s *Storage) GetEvent(ctx context.Context, id string) (*storage.Event, erro
 
 func (s *Storage) ListEvents(ctx context.Context, opts storage.QueryOptions) ([]*storage.Event, int, error) {
 	query := s.builder.
-		Select("id", "type", "headers", "payload", "created_at", "error", "repository", "sender").
+		Select("id", "type", "headers", "payload", "created_at", "forwarded_at", "error", "repository", "sender").
 		From(s.tableName)
 
 	query = s.addQueryConditions(query, opts)
@@ -179,6 +180,7 @@ func (s *Storage) ListEvents(ctx context.Context, opts storage.QueryOptions) ([]
 			&headers,
 			&payload,
 			&event.CreatedAt,
+			&event.ForwardedAt,
 			&event.Error,
 			&event.Repository,
 			&event.Sender,

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -23,13 +23,14 @@ type Event struct {
 
 // QueryOptions contains options for querying events
 type QueryOptions struct {
-	Types      []string  // Event types to filter by
-	Repository string    // Repository to filter by
-	Sender     string    // Sender to filter by
-	Since      time.Time // Start time for events
-	Until      time.Time // End time for events
-	Limit      int       // Maximum number of events to return
-	Offset     int       // Offset for pagination
+	Types            []string  // Event types to filter by
+	Repository       string    // Repository to filter by
+	Sender           string    // Sender to filter by
+	Since            time.Time // Start time for events
+	Until            time.Time // End time for events
+	Limit            int       // Maximum number of events to return
+	Offset           int       // Offset for pagination
+	OnlyNonForwarded bool      // Only return events that have not been forwarded (forwarded_at IS NULL)
 }
 
 // TypeStat represents event type statistics

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -13,6 +13,7 @@ type Event struct {
 	Headers      json.RawMessage `json:"headers"`
 	Payload      json.RawMessage `json:"payload"`
 	CreatedAt    time.Time       `json:"created_at"`
+	ForwardedAt  *time.Time      `json:"forwarded_at,omitempty"`
 	Error        string          `json:"error,omitempty"`
 	Repository   string          `json:"repository,omitempty"`
 	Sender       string          `json:"sender,omitempty"`


### PR DESCRIPTION
To support #40. Want to be able to query and write tests around the new `forwarded_at` being set or not.