### PR TITLE
Fix auto-forwarder bug with periodic event polling

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,66 @@
+name: Docker Build and Push
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine
+FROM golang:1.24-alpine
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.24-alpine
+FROM golang:1.24-alpine AS builder
+
+# Install build dependencies for CGO/SQLite
+RUN apk add --no-cache gcc musl-dev sqlite-dev
 
 WORKDIR /app
 
@@ -6,7 +9,18 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN go build -o /hubproxy ./cmd/hubproxy
+
+# Build with CGO enabled for SQLite
+RUN CGO_ENABLED=1 go build -o /hubproxy ./cmd/hubproxy
+
+FROM alpine:3.19
+
+# Install runtime dependencies for SQLite
+RUN apk add --no-cache sqlite-libs ca-certificates
+
+WORKDIR /app
+
+COPY --from=builder /hubproxy /hubproxy
 
 EXPOSE 8080 8081
 CMD ["/hubproxy"]

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOPATH := $(shell go env GOPATH)
 deps:
 	go mod download
 	go install golang.org/x/tools/cmd/goimports@latest
-	go install honnef.co/go/tools/cmd/staticcheck@latest
+	go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
 .PHONY: fmt

--- a/cmd/hubproxy/main.go
+++ b/cmd/hubproxy/main.go
@@ -96,6 +96,7 @@ and your target services.`,
 	flags.String("ts-authkey", "", "Tailscale auth key for tsnet")
 	flags.String("ts-hostname", "hubproxy", "Tailscale hostname (will be <hostname>.<tailnet>.ts.net)")
 	flags.String("db", "sqlite::memory:", "Database URI (e.g., sqlite:hubproxy.db, mysql://user:pass@host/db, postgres://user:pass@host/db)")
+	flags.String("forward-headers", "", "Additional headers to add when forwarding (format: Header:Value,Header2:Value2)")
 	flags.Duration("metrics-interval", 0*time.Minute, "Interval at which to gather database metrics")
 	flags.Bool("test-mode", false, "Skip server startup for testing")
 
@@ -219,6 +220,7 @@ func run() error {
 			Storage:          store,
 			MetricsCollector: metricsCollector,
 			Logger:           logger,
+			ForwardHeaders:   viper.GetString("forward-headers"),
 		})
 		go webhookForwarder.StartForwarder(ctx)
 	}


### PR DESCRIPTION
## Bug Description

The webhook forwarder had a bug where events were received and stored correctly, but never forwarded to the target URL automatically. Events would sit in the database with `forwarded_at = NULL` indefinitely.

## Root Cause

The original `StartForwarder()` implementation used a channel-based approach:
- Created a queue channel to signal when events should be processed
- Called `EnqueueProcessEvents()` once at startup
- Then waited passively for signals on the channel

The problem: the webhook handler never signaled the channel after storing new events, so the forwarder only ran once at startup and never again.

## Solution

Replaced the channel-based approach with a ticker that polls for unforwarded events every 10 seconds:

- Added `time` import
- `StartForwarder()` now creates a `time.NewTicker(10 * time.Second)`
- Processes events immediately on startup
- Then processes events every 10 seconds via the ticker
- Still respects context cancellation for graceful shutdown

## Changes

- Added `time` import to `internal/webhook/forwarder.go`
- Replaced channel-based `StartForwarder()` with ticker-based polling approach
- Removed the call to `EnqueueProcessEvents()` at startup (no longer needed)

## Testing

- Events will now be forwarded automatically within 10 seconds of being received
- Initial processing happens immediately on startup
- Errors are logged but don't stop the polling loop

Fixes the auto-forwarder to work without manual intervention.